### PR TITLE
Ignore disk info warnings in _get_machine_type() method

### DIFF
--- a/ducktape/cluster/remoteaccount.py
+++ b/ducktape/cluster/remoteaccount.py
@@ -162,6 +162,9 @@ class RemoteAccount(HttpMixin):
         boot_disk = self.ssh_output(boot_disk_cmd).strip()
         disks = {}
         for d in disk_info.splitlines():
+            # ignore Warnings
+            if re.match(r"WARNING", d):
+                continue
             d_name = re.match(r"(/dev/[a-z]+)", d).group(1)
             d_size = float(re.match(r"/dev/[a-z]+:\s*([\d|\.]+)\s*GB", d).group(1))
             disks[d_name] = d_size


### PR DESCRIPTION
For some VMs, we are seeing the disk info output as
`
WARNING: fdisk GPT support is currently new, and therefore in an experimental phase. Use at your own discretion.
/dev/sda: 32.2 GB
/dev/sdb: 107.4 GB
`

and `_get_machine_type()` method fails while trying to fetch the required parameters from the first line (i.e. Warning message).