### PR TITLE
Cherry-picked from confluentinc/ducktape: Fix generation of html report after py3 compatibility update

### DIFF
--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -173,23 +173,23 @@
       });
 
       SUMMARY=[{
-        "tests": {{num_tests}},
-        "passes": {{num_passes}},
-        "failures": {{num_failures}},
-        "ignored": {{num_ignored}},
-        "run_time": '{{run_time}}'
+        "tests": %(num_tests)d,
+        "passes": %(num_passes)d,
+        "failures": %(num_failures)d,
+        "ignored": %(num_ignored)d,
+        "run_time": '%(run_time)s'
       }];
       
       HEADING={
-        "ducktape_version": '{{ducktape_version}}',
-        "session": '{{session}}'
+        "ducktape_version": '%(ducktape_version)s',
+        "session": '%(session)s'
       };
 
-      COLOR_KEYS=[{{test_status_names}}];
+      COLOR_KEYS=[%(test_status_names)s];
 
-      PASSED_TESTS=[{{passed_tests}}];
-      FAILED_TESTS=[{{failed_tests}}];
-      IGNORED_TESTS=[{{ignored_tests}}];
+      PASSED_TESTS=[%(passed_tests)s];
+      FAILED_TESTS=[%(failed_tests)s];
+      IGNORED_TESTS=[%(ignored_tests)s];
 
       React.render(<Heading heading={HEADING}/>, document.getElementById('heading'));
       React.render(<ColorKeyPanel test_status_names={COLOR_KEYS}/>, document.getElementById('color_key_panel'));

--- a/ducktape/tests/reporter.py
+++ b/ducktape/tests/reporter.py
@@ -190,7 +190,7 @@ class HTMLSummaryReporter(SummaryReporter):
         return test_results_dir[len(base_dir):]  # truncate the "absolute" portion
 
     def format_report(self):
-        template = pkg_resources.resource_string(__name__, '../templates/report/report.html')
+        template = pkg_resources.resource_string(__name__, '../templates/report/report.html').decode('utf-8')
 
         num_tests = len(self.results)
         num_passes = 0
@@ -227,7 +227,7 @@ class HTMLSummaryReporter(SummaryReporter):
 
         html = template % args
         report_html = os.path.join(self.results.session_context.results_dir, "report.html")
-        with open(report_html, "wb") as fp:
+        with open(report_html, "w") as fp:
             fp.write(html)
             fp.close()
 


### PR DESCRIPTION
The py3 compatibility update had a bug such that it passed tests, but
didn't actually generate valid output for the report.html. This fixes it
by ensuring both py2 and py3 have a string to interpolate the result
data into.

Validated by running system tests and verifying the resulting
report.html files render correctly.