### PR TITLE
Fix insecure scripts in report.html

### DIFF
--- a/ducktape/templates/report/report.html
+++ b/ducktape/templates/report/report.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="http://fb.me/react-0.13.1.min.js"></script>
-    <script src="http://fb.me/JSXTransformer-0.13.1.js"></script>
+    <script src="https://fb.me/react-0.13.1.min.js"></script>
+    <script src="https://fb.me/JSXTransformer-0.13.1.js"></script>
   </head>
   <link rel="stylesheet" href="report.css" type="text/css">
   <body>


### PR DESCRIPTION
This PR is cherry-picked from confluentinc/ducktape to fix a bug that `report.html` has that causes it failed to load via https.

For example, check out this page with http and https:
* http://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2020-08-09--001.1596962320--confluentinc--master--7f21a17d2/report.html 
* https://confluent-kafka-system-test-results.s3-us-west-2.amazonaws.com/2020-08-09--001.1596962320--confluentinc--master--7f21a17d2/report.html

I found this issue because we're hosting the result reports with TeamCity server, and its connection is mandatorily https. Therefore, it's always a blank page when I open report.html from our TeamCity.

The original PR: https://github.com/confluentinc/ducktape/pull/243

